### PR TITLE
support openAboutWindow calls from the renderer process

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {app, BrowserWindow, shell} from 'electron';
+import {app, BrowserWindow, remote, shell} from 'electron';
 import {statSync} from 'fs';
 import * as path from 'path';
 
@@ -94,7 +94,7 @@ export default function openAboutWindow(info: AboutWindowInfo) {
         info.win_options || {},
     );
 
-    window = new BrowserWindow(options);
+    window = new (BrowserWindow || remote.BrowserWindow)(options);
 
     window.once('closed', () => {
         window = null;


### PR DESCRIPTION
openAboutWindow in https://github.com/rhysd/electron-about-window/blob/master/src/index.ts#L97 assumes that the call comes from the master process, i.e. where `electron.BrowserWindow` is defined.

this PR updates that line of code to handle the case where the call comes from the renderer process, where the call instead needs to of the `electron.remote.BrowserWindow` function.