### PR TITLE
Added optional close button for modal use

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [x] Gather package information from package.json
 - [x] Automatically detect package.json
 - [x] Adjust window size to its contents automatically
+- [x] Optional close button
 - [x] CSS customizability
 
 You can install this module via [npm](https://www.npmjs.com/).
@@ -38,6 +39,7 @@ export default function openAboutWindow(info: {
     adjust_window_size?: boolean;
     win_options?: BrowserWindowOptions;
     use_version_info?: boolean;
+    show_close_button?: string;
 }): BrowserWindow
 ```
 
@@ -88,6 +90,7 @@ $ npm run debug
 | `bug_link_text` | Text for a bug report link. **Optional** | string |
 | `product_name` | Name of the application **Optional** | string |
 | `use_version_info` | If `false`, the versions of electron, chrome, node, and v8 will not be displayed. Default is `true`. **Optional** | boolean |
+| `show_close_button` | If this is a valid string, a close button with this string be displayed. **Optional** | string |
 
 **Note:** If you set `use_inner_html` to `true`, please ensure that contents don't contain any untrusted external input
 in order to avoid XSS. Be careful.

--- a/about.html
+++ b/about.html
@@ -14,6 +14,7 @@
     <h3 class="description"></h3>
     <div class="copyright"></div>
     <table class="versions"></table>
+    <div class="buttons"></div>
     <footer class="footer">
       <div class="link bug-report-link"></div>
     </footer>

--- a/example/main.js
+++ b/example/main.js
@@ -32,6 +32,20 @@ app.once('ready', function() {
                             open_devtools: process.env.NODE_ENV !== 'production',
                         }),
                 },
+                {
+                    label: 'About This App (modal with close)',
+                    click: () =>
+                        openAboutWindow({
+                            icon_path: join(__dirname, 'icon.png'),
+                            copyright: 'Copyright (c) 2015 rhysd',
+                            package_json_dir: __dirname,
+                            win_options: {
+                                parent: w,
+                                modal: true,
+                            },
+                            show_close_button: "Close"
+                        }),
+                },
             ],
         },
     ]);

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ export interface AboutWindowInfo {
     open_devtools?: boolean;
     use_inner_html?: boolean;
     use_version_info?: boolean;
+    show_close_button?: string;
 }
 
 export default function openAboutWindow(into: AboutWindowInfo | string): Electron.BrowserWindow;

--- a/src/lib.d.ts
+++ b/src/lib.d.ts
@@ -31,6 +31,7 @@ interface AboutWindowInfo {
     use_inner_html?: boolean;
     bug_link_text?: string;
     use_version_info?: boolean;
+    show_close_button?: string;
 }
 
 declare namespace NodeJS {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -57,8 +57,12 @@ ipcRenderer.on('about-window:info', (_: any, info: AboutWindowInfo) => {
         const win = remote.getCurrentWindow();
         if (height > 0 && width > 0) {
             // Note:
-            // Add 30px(= about 2em) to add padding in window
-            win.setContentSize(width, height + 40);
+            // Add 30px(= about 2em) to add padding in window, if there is a close button, bit more
+            if (info.show_close_button) {
+                win.setContentSize(width, height + 40);
+            } else {
+                win.setContentSize(width, height + 52);
+            }
         }
     }
 
@@ -75,5 +79,17 @@ ipcRenderer.on('about-window:info', (_: any, info: AboutWindowInfo) => {
             tr.appendChild(version_td);
             versions.appendChild(tr);
         }
+    }
+
+    if (info.show_close_button) {
+        const buttons = document.querySelector('.buttons');
+        const close_button = document.createElement('button');
+        close_button.innerText = info.show_close_button;
+        close_button.addEventListener('click', e => {
+            e.preventDefault();
+            remote.getCurrentWindow().close();
+        });
+        buttons.appendChild(close_button);
+        close_button.focus();
     }
 });

--- a/styles/ui.css
+++ b/styles/ui.css
@@ -50,6 +50,17 @@ body {
   color: #999;
 }
 
+.buttons {
+  margin-bottom: 1em;
+  text-align: center;
+}
+
+.buttons button {
+  margin-top: 1em;
+  width: 100px;
+  height: 24px;
+}
+
 .link {
   cursor: pointer;
   color: #80a0c2;


### PR DESCRIPTION
This change allows adding a close button for modal about boxes, added a second menu item to the sample app to show how to use a modal about box with a close button.