### PR TITLE
Updated CSS to work on frameless windows

### DIFF
--- a/styles/ui.css
+++ b/styles/ui.css
@@ -67,8 +67,13 @@ body {
 }
 
 .bug-report-link {
-  -webkit-app-region: no-drag;
   position: absolute;
   right: 0.5em;
   bottom: 0.5em;
+}
+
+.clickable,
+.bug-report-link
+.buttons button {
+    -webkit-app-region: no-drag;
 }


### PR DESCRIPTION
When making the window frameless, the logo and the close button were not clickable anymore as they became drag regions.

This simple CSS fix takes care of that