### PR TITLE
Adding "resizable" props for BrowserWindow

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ export default function openAboutWindow(info: {
     adjust_window_size?: boolean;
     win_options?: BrowserWindowOptions;
     use_version_info?: boolean;
+    resizable?: boolean;
     show_close_button?: string;
 }): BrowserWindow
 ```
@@ -91,6 +92,7 @@ $ npm run debug
 | `bug_link_text` | Text for a bug report link. **Optional** | string |
 | `product_name` | Name of the application **Optional** | string |
 | `use_version_info` | If `false`, the versions of electron, chrome, node, and v8 will not be displayed. Default is `true`. **Optional** | boolean |
+| `resizable` | Whether window is resizable. Default is `true`. **Optional** | boolean |
 | `show_close_button` | If this is a valid string, a close button with this string be displayed. **Optional** | string |
 | `about_page_dir` | Directory path which contains `about.html` which is rendered in 'About this app' window. **Optional** | string |
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ export interface AboutWindowInfo {
     open_devtools?: boolean;
     use_inner_html?: boolean;
     use_version_info?: boolean;
+    resizable?: boolean;
     show_close_button?: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,7 @@ export default function openAboutWindow(info_or_img_path: AboutWindowInfo | stri
             titleBarStyle: 'hidden-inset',
             show: !info.adjust_window_size,
             icon: info.icon_path,
+            resizable: info.resizable || true,
             webPreferences: {
                 // For security reasons, nodeIntegration is no longer true by default when using Electron v5 or later
                 // nodeIntegration can be safely enabled as long as the window source is not remote

--- a/src/lib.d.ts
+++ b/src/lib.d.ts
@@ -32,6 +32,7 @@ interface AboutWindowInfo {
     use_inner_html?: boolean;
     bug_link_text?: string;
     use_version_info?: boolean;
+    resizable?: boolean;
     show_close_button?: string;
 }
 


### PR DESCRIPTION
This PR gives the ability to choose whether the window is resizable or not.
The default value is `true` as it comes with electron