### PR TITLE
Handle window options passed in an immutable manner

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -18,6 +18,20 @@ app.once('ready', function() {
     });
     w.loadURL('file://' + join(__dirname, 'index.html'));
 
+    const options = {
+        icon_path: join(__dirname, 'icon.png'),
+        copyright: 'Copyright (c) 2015 rhysd',
+        package_json_dir: __dirname,
+        win_options: {
+            resizable: false,
+            minimizable: false,
+            maximizable: false,
+            movable: false,
+            parent: w,
+            modal: true,
+        }
+    }
+
     const menu = Menu.buildFromTemplate([
         {
             label: 'Example',
@@ -45,6 +59,11 @@ app.once('ready', function() {
                             },
                             show_close_button: "Close"
                         }),
+                },
+                {
+                    label: 'About This App (modal with options)',
+                    click: () =>
+                        openAboutWindow(options),
                 },
             ],
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ function normalizeParam(info_or_img_path: AboutWindowInfo | string | undefined |
                 "First parameter of openAboutWindow() must have key 'icon_path'. Please see the document: https://github.com/rhysd/electron-about-window/blob/master/README.md",
             );
         }
-        return info;
+        return { ...info };
     }
 }
 


### PR DESCRIPTION
Return a clone of `AboutWindowInfo` object from `normalizeParam` function to ensure the immutable state of `win_options`.